### PR TITLE
[JENKINS-66300] Prepare Relution Enterprise Appstore Publisher for core Guava upgrade

### DIFF
--- a/relution-publisher/pom.xml
+++ b/relution-publisher/pom.xml
@@ -56,14 +56,14 @@
 	<repositories>
 		<repository>
 			<id>repo.jenkins-ci.org</id>
-			<url>http://repo.jenkins-ci.org/public/</url>
+			<url>https://repo.jenkins-ci.org/public/</url>
 		</repository>
 	</repositories>
 
 	<pluginRepositories>
 		<pluginRepository>
 			<id>repo.jenkins-ci.org</id>
-			<url>http://repo.jenkins-ci.org/public/</url>
+			<url>https://repo.jenkins-ci.org/public/</url>
 		</pluginRepository>
 	</pluginRepositories>
 

--- a/relution-publisher/src/main/java/org/jenkinsci/plugins/relution_publisher/builder/SingleRequestUploader.java
+++ b/relution-publisher/src/main/java/org/jenkinsci/plugins/relution_publisher/builder/SingleRequestUploader.java
@@ -16,8 +16,6 @@
 
 package org.jenkinsci.plugins.relution_publisher.builder;
 
-import com.google.common.base.Stopwatch;
-
 import org.apache.commons.lang.StringUtils;
 import org.apache.tools.ant.DirectoryScanner;
 import org.apache.tools.ant.types.FileSet;
@@ -126,14 +124,13 @@ public class SingleRequestUploader implements Uploader {
             request.addItem("changelog", changelog);
         }
 
-        final Stopwatch sw = new Stopwatch();
-
-        sw.start();
+        long startTimeNanos = System.nanoTime();
         final ApiResponse response = this.network.execute(request, this.log);
-        sw.stop();
+        long finishTimeNanos = System.nanoTime();
+        long elapsedTimeMillis = TimeUnit.MILLISECONDS.convert(finishTimeNanos - startTimeNanos, TimeUnit.NANOSECONDS);
 
-        final String speed = this.getUploadSpeed(sw, request);
-        this.log.write(this, "Upload completed (%s, %s)", sw, speed);
+        final String speed = this.getUploadSpeed(elapsedTimeMillis, request);
+        this.log.write(this, "Upload completed (%s milliseconds, %s)", elapsedTimeMillis, speed);
 
         return response;
     }
@@ -241,8 +238,8 @@ public class SingleRequestUploader implements Uploader {
         return new File(scanner.getBasedir(), fileName);
     }
 
-    private String getUploadSpeed(final Stopwatch sw, final ZeroCopyFileRequest request) throws FileNotFoundException {
-        final float milliseconds = sw.elapsedTime(TimeUnit.MILLISECONDS);
+    private String getUploadSpeed(final long elapsedTimeMillis, final ZeroCopyFileRequest request) throws FileNotFoundException {
+        final float milliseconds = elapsedTimeMillis;
         final float seconds = milliseconds / 1000f;
 
         final long length = request.getContentLength();


### PR DESCRIPTION
See [JENKINS-66300](https://issues.jenkins.io/browse/JENKINS-66300) and [JENKINS-65988](https://issues.jenkins.io/browse/JENKINS-65988). Jenkins core is using [Guava 11.0.1](https://github.com/google/guava/releases/tag/v11.0.1), which was released on January 9, 2012. Jenkins core would like to upgrade to [Guava 30.1.1](https://github.com/google/guava/releases/tag/v30.1.1), which was released on March 19, 2021. Plugins must be prepared to be compatible with both Guava 11.0.1 and Guava 30.1.1 in advance of this core transition.

In particular, this plugin has been identified as using the `com.google.common.base.Stopwatch` API, which has changed between Guava [11.0.1](https://guava.dev/releases/11.0.1/api/docs/com/google/common/base/Stopwatch.html) and [latest](https://guava.dev/releases/snapshot-jre/api/docs/com/google/common/base/Stopwatch.html). The following methods exist in Guava 11.0.1 but not latest:

 * `Stopwatch#elapsedMillis()`
 * `Stopwatch#elapsedTime(TimeUnit desiredUnit)`
 * `Stopwatch#toString(int significantDigits)`

To facilitate the Jenkins core transition, this plugin must be prepared and released such that it works with both Guava 11.0.1 and latest. In this PR, we migrate away from the Stopwatch API and use `System#nanoTime` directly. This eliminates this plugin's dependency on Guava and prepares it for the Jenkins core transition from Guava 11.0.1 to latest.

CC @mpfeiffermway